### PR TITLE
feat: add support for publishing logo and diagram from a local file using Widoco plugin

### DIFF
--- a/.env.dev.template
+++ b/.env.dev.template
@@ -1,12 +1,15 @@
 # Copy to .env for local dev run
 # Expects the app to be running in ./target
+ONTOPUS_DATABASE_URL=http://localhost:7200/repositories/ontopus
+
 ONTOPUS_SYSTEM_URI=http://localhost
 ONTOPUS_ADMINISTRATION_ALLOWED_ORIGINS=http://localhost:5173,http://localhost
+
 ONTOPUS_PLUGIN_WIDOCO_FILES_DIRECTORY=./widoco
 ONTOPUS_PLUGIN_WIDOCO_PATH=${ONTOPUS_PLUGIN_WIDOCO_FILES_DIRECTORY}
 ONTOPUS_FRONTEND_INDEX_FILE=../administration-frontend/dist/index.html
-SERVER_PORT=80
 
+SERVER_PORT=80
 
 # OR with port 8080
 # ONTOPUS_SYSTEM_URI=http://localhost:8080

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -24,6 +24,7 @@
 | ```ONTOPUS_PLUGIN_WIDOCO_DOWNLOAD_URL``` | Default value: ```https://github.com/dgarijo/Widoco/releases/download/v{version}/widoco-{version}-jar-with-dependencies_JDK-17.jar``` |
 | ```ONTOPUS_PLUGIN_WIDOCO_DOWNLOAD_URL_PARAMETERS``` | Widoco version to automatically download<br>Default value: ```Map.of("version", "1.4.25")``` |
 | ```ONTOPUS_PLUGIN_WIDOCO_FORCE_HTTPS_FOR_SERIALIZATION_LINKS``` | Whether the links to ontology serializations should use the ontology IRI schema or forced to use HTTPS schema.<br>When ```true```, the links to ontology serialization will always be generated with HTTPS.<br>Default value: ```false``` |
+| ```ONTOPUS_PLUGIN_WIDOCO_RELATIVE_FILE_PATH_PROPERTIES``` | A list of ontology properties that may contain a relative file path that should be included in the resulting<br>documentation.<br>Default value: ```Stream.of("http://schema.org/image", "http://xmlns.com/foaf/0.1/depiction", "http://schema.org/logo", "http://xmlns.com/foaf/0.1/logo").map(URI::create).collect(Collectors.toSet())``` |
 | ```ONTOPUS_RESOURCE_CACHE_CONTROL_MAX_AGE``` | The value of ```max-age``` in cache control HTTP header<br>Default value: ```Duration.ofHours(1)``` |
 | ```ONTOPUS_RESOURCE_FALLBACK_MEDIATYPE``` | Which content type should be preferred when no other acceptable type is available.<br>Default value: ```text/turtle``` |
 | ```ONTOPUS_RESOURCE_HTTPS_FALLS_BACK_TO_HTTP``` | Request to ```https``` prefixed resource that does not exist, will fall back to the same resource with ```http```.<br>Default value: ```true``` |

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -78,6 +78,45 @@ Currently, the server does not have a user management implemented, to change the
 
 7. Access the administration interface at the system URI (e.g. http://ontopus.example.com/admin) and log in with the created user
 
+## Reverse Proxy Servers
+When placing OntoPuS behind a reverse proxy servers, they need to properly add forward HTTP headers
+for ontopus to resolve URIs correctly.
+
+If using the [docker compose](./docker/docker-compose.yaml) with nginx, 
+make sure to update the [ontopus_proxy_pass.conf](./docker/nginx/includes/ontopus_proxy_pass.conf) based on your setup.
+
+**Proxy redirecting HTTP to HTTPS**  
+Proxy configuration redirecting from HTTP to HTTPS should add the following HTTP headers to
+accept any cross-origin and instruct browsers to upgrade insecure requests from HTTP to HTTPS.
+
+Note that requests going to OntoPuS are likely not exclusive to the OntoPuS system URI but also all your domains used in ontologies.
+```
+Access-Control-Allow-Origin "*"
+Content-Security-Policy "upgrade-insecure-requests"
+```
+
+**First proxy**  
+The first proxy that is being hit by the client (or other proxy depending on your setup that has the information from original request available)
+should also set the content security policy header for upgrading insecure requests,
+needs to set the forwarded protocol and port and needs to be configured to **preserve the original Host**.
+```
+Content-Security-Policy "upgrade-insecure-requests"
+X-Forwarded-Proto "https"
+X-Forwarded-Port "443"
+```
+Preserving original Host:
+```
+# Apache2:
+ProxyPreserveHost On
+
+# Nginx:
+proxy_set_header Host $http_host;
+```
+
+**Any other intermediate proxy**
+If there are multiple proxies the other between the first proxy and ontopus
+must not modify the forwarded headers and must also **preserve the original Host**
+
 ## Changing the user account password
 The password value uses bcrypt hash.
 The hash can be generated for example with [CyberChef](https://cyberchef.org/#recipe=Bcrypt(10)&input=YWJlY2VkYQ).

--- a/core-model/ontology/ontopus.ttl
+++ b/core-model/ontology/ontopus.ttl
@@ -26,10 +26,13 @@
                                                     <http://purl.org/vocab/vann/preferredNamespaceUri> "http://ontology.lukaskabc.cz/application/ontopus/" ;
                                                     sh:suggestedShapesGraph <http://ontology.lukaskabc.cz/application/ontopus/shacl> ;
                                                     rdfs:comment "Ontology Publication Server"@en ;
+                                                    rdfs:comment "Ontologický Publikační Server"@cs ;
                                                     rdfs:label "OntoPuS" ;
+                                                    rdfs:label "OntoPuS"@cs ;
+                                                    rdfs:label "OntoPuS"@en ;
                                                     foaf:logo "../../administration-frontend/src/assets/logo.svg" ;
-                                                    owl:versionIRI <http://ontology.lukaskabc.cz/application/ontopus/0.1.0> ;
-                                                    owl:versionInfo "Version 0.1.0"@en .
+                                                    owl:versionIRI <http://ontology.lukaskabc.cz/application/ontopus/0.1.1> ;
+                                                    owl:versionInfo "Version 0.1.1"@en .
 
 hydra:Error a hydra:Class ;
     rdfs:label "Error" ;

--- a/core-model/ontology/ontopus.ttl
+++ b/core-model/ontology/ontopus.ttl
@@ -27,6 +27,7 @@
                                                     sh:suggestedShapesGraph <http://ontology.lukaskabc.cz/application/ontopus/shacl> ;
                                                     rdfs:comment "Ontology Publication Server"@en ;
                                                     rdfs:label "OntoPuS" ;
+                                                    foaf:logo "../../administration-frontend/src/assets/logo.svg" ;
                                                     owl:versionIRI <http://ontology.lukaskabc.cz/application/ontopus/0.1.0> ;
                                                     owl:versionInfo "Version 0.1.0"@en .
 

--- a/core-model/src/main/java/cz/lukaskabc/ontology/ontopus/core_model/persistence/dao/VersionArtifactDao.java
+++ b/core-model/src/main/java/cz/lukaskabc/ontology/ontopus/core_model/persistence/dao/VersionArtifactDao.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import java.util.Comparator;
 import java.util.List;
 
 @Component
@@ -148,18 +147,14 @@ public class VersionArtifactDao extends AbstractDao<VersionArtifactURI, VersionA
      */
     public List<PrefixDeclaration> findPrefixDeclarations(OntologyVersionURI ontologyVersionURI) {
         try {
-            final List<PrefixDeclaration> result = em.createQuery("""
+            return em.createQuery("""
 					    SELECT artifact.prefixDeclarations
 					    FROM VersionArtifact artifact
 					    WHERE artifact.versionUri = :iri
+					    ORDER BY artifact.prefixDeclarations.prefix, artifact.prefixDeclarations.namespace
 					""", PrefixDeclaration.class)
                     .setParameter("iri", ontologyVersionURI.toURI())
                     .getResultList();
-            result.sort(
-                    Comparator.comparing(PrefixDeclaration::getPrefix).thenComparing(PrefixDeclaration::getNamespace));
-            // FIXME: Replace sort with ORDER BY once
-            // https://github.com/kbss-cvut/jopa/issues/460 is resolved
-            return result;
         } catch (Exception e) {
             throw AbstractDao.persistenceException(
                     log, "Failed to find prefix declarations for artifact " + ontologyVersionURI, e);

--- a/dev-docker-compose.yaml
+++ b/dev-docker-compose.yaml
@@ -12,9 +12,12 @@ services:
     domainname: "ontopus"
     ports:
       - "8080:8080"
+      - "5005:5005"
     depends_on:
       graphdb:
         condition: "service_healthy"
+    # Allows Java debugging
+    entrypoint: ["java", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005", "-jar", "./core.jar"]
     environment:
       # passthrough variables from .env file
       ONTOPUS_DATABASE_URL: "${ONTOPUS_DATABASE_URL}"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
         condition: "service_healthy"
     environment:
       ONTOPUS_DATABASE_URL: "http://graphdb:7200/repositories/ontopus"
+
       ONTOPUS_SYSTEM_URI: "http://localhost" # base path is NOT allowed
 
       # Configure the publisher of the DCAT catalog

--- a/docker/nginx/includes/ontopus_proxy_pass.conf
+++ b/docker/nginx/includes/ontopus_proxy_pass.conf
@@ -1,9 +1,15 @@
-
-
+# If NGINX is the first proxy being hit by the client
+# Use following headers:
 proxy_set_header Host $host:$server_port;
 proxy_set_header X-Forwarded-Host $server_name;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+# Instruct browsers to always upgrade HTTP requests to HTTPS:
+proxy_set_header Content-Security-Policy "upgrade-insecure-requests";
+
+# If NGINX is behind another proxy, comment out the options above and use only
+# proxy_set_header Host $http_host;
 
 proxy_pass http://ontopus:8080;

--- a/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/service/import_process/OntologyAnnotationInjectionService.java
+++ b/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/service/import_process/OntologyAnnotationInjectionService.java
@@ -1,10 +1,13 @@
 package cz.lukaskabc.ontology.ontopus.api.service.import_process;
 
 import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 
 /**
  * Resolves statements to be injected into the original ontology.
  *
  * @implNote the service will be put to the stack automatically and the returned model will be automatically persisted.
  */
-public interface OntologyAnnotationInjectionService extends ImportProcessingService<Model> {}
+public interface OntologyAnnotationInjectionService extends ImportProcessingService<Model> {
+    static final Model EMPTY_MODEL = new LinkedHashModel();
+}

--- a/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/service/init/DirectoryInitializationService.java
+++ b/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/service/init/DirectoryInitializationService.java
@@ -1,0 +1,50 @@
+package cz.lukaskabc.ontology.ontopus.api.service.init;
+
+import cz.lukaskabc.ontology.ontopus.api.service.core.InitializationService;
+import cz.lukaskabc.ontology.ontopus.core_model.exception.InitializationException;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+/** Ensures that {@link #directories} exist and are writable and readable */
+public abstract class DirectoryInitializationService implements InitializationService {
+    public static final int ORDER = 500;
+    private final Set<Path> directories;
+
+    public DirectoryInitializationService(Path directory) {
+        this.directories = Set.of(directory);
+    }
+
+    public DirectoryInitializationService(Set<Path> directories) {
+        this.directories = directories;
+    }
+
+    protected void ensureDirectoryValid(Path directory) {
+        final File filesDirectory = directory.toFile();
+        if (!filesDirectory.exists()) {
+            final boolean success = filesDirectory.mkdirs();
+            if (!success) {
+                throw new InitializationException("Failed to create directory at " + filesDirectory.getAbsolutePath());
+            }
+        }
+        if (!filesDirectory.isDirectory()) {
+            throw new InitializationException(
+                    "Directory is missing or not a directory: " + filesDirectory.getAbsolutePath());
+        }
+        if (!Files.isWritable(filesDirectory.toPath())) {
+            throw new InitializationException("Directory is not writable: " + filesDirectory.getAbsolutePath());
+        }
+        if (!Files.isReadable(filesDirectory.toPath())) {
+            throw new InitializationException("Directory is not readable: " + filesDirectory.getAbsolutePath());
+        }
+    }
+
+    @Override
+    public void initialize() {
+        for (Path directory : directories) {
+            ensureDirectoryValid(directory);
+        }
+    }
+}

--- a/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
+++ b/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
@@ -16,17 +16,22 @@ import java.util.stream.Stream;
 public class FileUtils {
     private static final Logger log = LogManager.getLogger(FileUtils.class);
 
+    /** Strips any root component, forcing the path to be relative. */
     public static Path forceRelativePath(String pathString) {
-        Objects.requireNonNull(pathString);
-        final Path path = Path.of(pathString);
-        if (path.startsWith("/") || path.startsWith("\\")) {
-            return Path.of("/").relativize(path);
+        Objects.requireNonNull(pathString, "pathString must not be null");
+        Path path = Path.of(pathString);
+
+        if (path.isAbsolute() || path.getRoot() != null) {
+            Path root = path.getRoot();
+            return root != null ? root.relativize(path) : path;
         }
+
         return path;
     }
 
     @MustBeClosed
     public static Stream<Path> listRecursively(Path directory) {
+        Objects.requireNonNull(directory, "directory must not be null");
         try {
             return Files.walk(directory);
         } catch (IOException e) {
@@ -59,6 +64,10 @@ public class FileUtils {
      * @throws ValidationException if the resolved path escapes the absolute root directory
      */
     public static Path resolvePath(final Path absoluteRoot, final Path baseDirPath, final Path userPath) {
+        Objects.requireNonNull(absoluteRoot, "absoluteRoot must not be null");
+        Objects.requireNonNull(baseDirPath, "baseDirPath must not be null");
+        Objects.requireNonNull(userPath, "userPath must not be null");
+
         if (!absoluteRoot.isAbsolute()) {
             throw ValidationException.builder()
                     .internalMessage("Root path must be absolute")
@@ -80,14 +89,25 @@ public class FileUtils {
                     .build();
         }
 
+        // Normalize roots and base paths to ensure consistent segment comparisons
+        final Path normalizedRoot = absoluteRoot.normalize();
+        final Path normalizedBase = baseDirPath.normalize();
+
+        if (!normalizedBase.startsWith(normalizedRoot)) {
+            throw ValidationException.builder()
+                    .internalMessage("Base directory is outside of the absolute root directory")
+                    .detailMessageArguments(OntopusException.EMPTY_ARGUMENTS)
+                    .build();
+        }
+
         // Join the two paths together, then normalize so that any ".." elements
         // in the userPath can remove parts of baseDirPath.
         // (e.g. "/foo/bar/baz" + "../attack" -> "/foo/bar/attack")
-        final Path resolvedPath = baseDirPath.resolve(userPath).normalize();
+        final Path resolvedPath = normalizedBase.resolve(userPath).normalize();
 
         // Make sure the resulting path is still within the required directory.
         // (In the example above, "/foo/bar/attack" is not.)
-        if (!resolvedPath.startsWith(absoluteRoot)) {
+        if (!resolvedPath.startsWith(normalizedRoot)) {
             throw ValidationException.builder()
                     .internalMessage("User path escapes the absolute root directory")
                     .detailMessageArguments(OntopusException.EMPTY_ARGUMENTS)

--- a/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
+++ b/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
@@ -44,6 +44,28 @@ public class FileUtils {
      * @throws ValidationException if the resolved path escapes the base directory
      */
     public static Path resolvePath(final Path baseDirPath, final Path userPath) {
+        return resolvePath(baseDirPath, baseDirPath, userPath);
+    }
+
+    /**
+     * Resolves an untrusted user-specified path against the API's base directory. Paths that try to escape the absolute
+     * root directory are rejected.
+     *
+     * @param absoluteRoot the absolute path of the root directory that all user-specified paths should be within
+     * @param baseDirPath the absolute path against which the user path should be resolved
+     * @param userPath the untrusted path provided by the API user, expected to be relative to {@code baseDirPath} and
+     *     must not escape {@code absoluteRoot}
+     * @see <a href="https://stackoverflow.com/a/33084369/12690791">Author at StackOverflow</a>
+     * @throws ValidationException if the resolved path escapes the absolute root directory
+     */
+    public static Path resolvePath(final Path absoluteRoot, final Path baseDirPath, final Path userPath) {
+        if (!absoluteRoot.isAbsolute()) {
+            throw ValidationException.builder()
+                    .internalMessage("Root path must be absolute")
+                    .detailMessageArguments(OntopusException.EMPTY_ARGUMENTS)
+                    .build();
+        }
+
         if (!baseDirPath.isAbsolute()) {
             throw ValidationException.builder()
                     .internalMessage("Base path must be absolute")
@@ -65,9 +87,9 @@ public class FileUtils {
 
         // Make sure the resulting path is still within the required directory.
         // (In the example above, "/foo/bar/attack" is not.)
-        if (!resolvedPath.startsWith(baseDirPath)) {
+        if (!resolvedPath.startsWith(absoluteRoot)) {
             throw ValidationException.builder()
-                    .internalMessage("User path escapes the base path")
+                    .internalMessage("User path escapes the absolute root directory")
                     .detailMessageArguments(OntopusException.EMPTY_ARGUMENTS)
                     .build();
         }

--- a/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
+++ b/plugin-api/src/main/java/cz/lukaskabc/ontology/ontopus/api/util/FileUtils.java
@@ -41,6 +41,7 @@ public class FileUtils {
      * @param baseDirPath the absolute path of the base directory that all user-specified paths should be within
      * @param userPath the untrusted path provided by the API user, expected to be relative to {@code baseDirPath}
      * @see <a href="https://stackoverflow.com/a/33084369/12690791">Author at StackOverflow</a>
+     * @throws ValidationException if the resolved path escapes the base directory
      */
     public static Path resolvePath(final Path baseDirPath, final Path userPath) {
         if (!baseDirPath.isAbsolute()) {

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/config/WidocoPluginConfig.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/config/WidocoPluginConfig.java
@@ -6,9 +6,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotNull;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Validated
 @NullUnmarked
@@ -35,6 +39,20 @@ public class WidocoPluginConfig {
      */
     private boolean forceHttpsForSerializationLinks = false;
 
+    /**
+     * A list of ontology properties that may contain a relative file path that should be included in the resulting
+     * documentation.
+     */
+    private Set<URI> relativeFilePathProperties = Stream.of(
+                    // Diagram
+                    // https://dgarijo.github.io/Widoco/doc/bestPractices/index-en.html#diagram
+                    "http://schema.org/image", "http://xmlns.com/foaf/0.1/depiction",
+                    // Logo
+                    // https://dgarijo.github.io/Widoco/doc/bestPractices/index-en.html#logo
+                    "http://schema.org/logo", "http://xmlns.com/foaf/0.1/logo")
+            .map(URI::create)
+            .collect(Collectors.toSet());
+
     public String getDownloadUrl() {
         return downloadUrl;
     }
@@ -53,6 +71,10 @@ public class WidocoPluginConfig {
 
     public Path getPath() {
         return path;
+    }
+
+    public Set<URI> getRelativeFilePathProperties() {
+        return relativeFilePathProperties;
     }
 
     public boolean isForceHttpsForSerializationLinks() {
@@ -82,5 +104,9 @@ public class WidocoPluginConfig {
 
     public void setPath(Path path) {
         this.path = path.toAbsolutePath();
+    }
+
+    public void setRelativeFilePathProperties(Set<URI> relativeFilePathProperties) {
+        this.relativeFilePathProperties = relativeFilePathProperties;
     }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/dao/OntologyDao.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/dao/OntologyDao.java
@@ -93,4 +93,42 @@ public class OntologyDao {
                     log, "Failed to find value for subject " + subject + " and predicate " + predicate, e);
         }
     }
+
+    public void replaceObjectStringValue(
+            GraphURI graphURI, OntologyURI subject, ResourceURI predicate, String originalValue, String newValue) {
+        Objects.requireNonNull(graphURI);
+        Objects.requireNonNull(subject);
+        Objects.requireNonNull(originalValue);
+        Objects.requireNonNull(newValue);
+        try {
+            entityManager
+                    .createNativeQuery("""
+					    DELETE {
+					        GRAPH ?context {
+					            ?subject ?predicate ?oldValue .
+					        }
+					    } INSERT {
+					        GRAPH ?context {
+					            ?subject ?predicate ?newValue .
+					        }
+					    } WHERE {
+					        GRAPH ?context {
+					            ?subject ?predicate ?oldValue .
+					        }
+					    }
+					""")
+                    .setParameter("context", graphURI.toURI())
+                    .setParameter("subject", subject.toURI())
+                    .setParameter("predicate", predicate.toURI())
+                    .setParameter("oldValue", originalValue)
+                    .setParameter("newValue", newValue)
+                    .executeUpdate();
+        } catch (Exception e) {
+            throw AbstractDao.persistenceException(
+                    log,
+                    "Failed to replace object for triple <" + subject + "> <" + predicate + "> '" + originalValue
+                            + "' with '" + newValue + "'",
+                    e);
+        }
+    }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/dao/OntologyDao.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/dao/OntologyDao.java
@@ -2,7 +2,10 @@ package cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.dao;
 
 import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.lukaskabc.ontology.ontopus.core_model.generated.Vocabulary;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.GraphURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.OntologyURI;
 import cz.lukaskabc.ontology.ontopus.core_model.model.id.OntologyVersionURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
 import cz.lukaskabc.ontology.ontopus.core_model.model.ontology.VersionArtifact_;
 import cz.lukaskabc.ontology.ontopus.core_model.model.ontology.VersionSeries_;
 import cz.lukaskabc.ontology.ontopus.core_model.persistence.dao.base.AbstractDao;
@@ -12,6 +15,8 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class OntologyDao {
@@ -64,6 +69,28 @@ public class OntologyDao {
         } catch (Exception e) {
             throw AbstractDao.persistenceException(
                     log, "Failed to find a preferred namespace for ontology version " + versionURI, e);
+        }
+    }
+
+    public Set<String> findValue(GraphURI graphURI, OntologyURI subject, ResourceURI predicate) {
+        Objects.requireNonNull(graphURI);
+        Objects.requireNonNull(subject);
+        Objects.requireNonNull(predicate);
+        try {
+            return entityManager
+                    .createNativeQuery("""
+					    SELECT ?value FROM ?graph WHERE {
+					        ?subject ?predicate ?value .
+					    }
+					""", String.class)
+                    .setParameter("graph", graphURI.toURI())
+                    .setParameter("subject", subject.toURI())
+                    .setParameter("predicate", predicate.toURI())
+                    .getResultStream()
+                    .collect(Collectors.toSet());
+        } catch (Exception e) {
+            throw AbstractDao.persistenceException(
+                    log, "Failed to find value for subject " + subject + " and predicate " + predicate, e);
         }
     }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/repository/OntologyRepository.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/repository/OntologyRepository.java
@@ -1,11 +1,15 @@
 package cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.repository;
 
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.GraphURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.OntologyURI;
 import cz.lukaskabc.ontology.ontopus.core_model.model.id.OntologyVersionURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
 import cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.dao.OntologyDao;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URI;
+import java.util.Set;
 
 @Repository
 public class OntologyRepository {
@@ -18,5 +22,10 @@ public class OntologyRepository {
     @Transactional(readOnly = true)
     public URI findPreferredNamespaceByVersionURI(OntologyVersionURI versionURI) {
         return dao.findPreferredNamespaceByVersionURI(versionURI);
+    }
+
+    @Transactional(readOnly = true)
+    public Set<String> findValue(GraphURI graphURI, OntologyURI subject, ResourceURI predicate) {
+        return dao.findValue(graphURI, subject, predicate);
     }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/repository/OntologyRepository.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/repository/OntologyRepository.java
@@ -28,4 +28,10 @@ public class OntologyRepository {
     public Set<String> findValue(GraphURI graphURI, OntologyURI subject, ResourceURI predicate) {
         return dao.findValue(graphURI, subject, predicate);
     }
+
+    @Transactional
+    public void replaceObjectStringValue(
+            GraphURI graphURI, OntologyURI subject, ResourceURI predicate, String originalValue, String newValue) {
+        dao.replaceObjectStringValue(graphURI, subject, predicate, originalValue, newValue);
+    }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/service/OntologyService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/service/OntologyService.java
@@ -1,0 +1,22 @@
+package cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.service;
+
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.GraphURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.OntologyURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.repository.OntologyRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+public class OntologyService {
+    private final OntologyRepository ontologyRepository;
+
+    public OntologyService(OntologyRepository ontologyRepository) {
+        this.ontologyRepository = ontologyRepository;
+    }
+
+    public Set<String> findValue(GraphURI graphURI, OntologyURI subject, ResourceURI predicate) {
+        return ontologyRepository.findValue(graphURI, subject, predicate);
+    }
+}

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/service/OntologyService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/persistence/service/OntologyService.java
@@ -19,4 +19,9 @@ public class OntologyService {
     public Set<String> findValue(GraphURI graphURI, OntologyURI subject, ResourceURI predicate) {
         return ontologyRepository.findValue(graphURI, subject, predicate);
     }
+
+    public void replaceObjectStringValue(
+            GraphURI graphURI, OntologyURI subject, ResourceURI predicate, String originalValue, String newValue) {
+        ontologyRepository.replaceObjectStringValue(graphURI, subject, predicate, originalValue, newValue);
+    }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
@@ -74,7 +74,7 @@ public class AdditionalFilesPersistingService {
             ImportProcessContext context, URI property, Path ontologyFileDir, Path filesDestination) {
         final Set<Path> resolvedPaths = resolveProperty(context, property);
         for (Path path : resolvedPaths) {
-            final Path safeSource = FileUtils.resolvePath(ontologyFileDir, path);
+            final Path safeSource = FileUtils.resolvePath(context.getTempFolder(), ontologyFileDir, path);
             copyFile(safeSource, filesDestination.resolve(path));
         }
     }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
@@ -5,22 +5,18 @@ import cz.lukaskabc.ontology.ontopus.api.util.FileUtils;
 import cz.lukaskabc.ontology.ontopus.core_model.exception.InternalException;
 import cz.lukaskabc.ontology.ontopus.core_model.exception.OntopusException;
 import cz.lukaskabc.ontology.ontopus.core_model.generated.Vocabulary;
-import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
 import cz.lukaskabc.ontology.ontopus.plugin.widoco.config.WidocoPluginConfig;
-import cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.service.OntologyService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.List;
 
 /**
  * Resolves {@link WidocoPluginConfig#relativeFilePathProperties} on the ontology and tries to match their values
@@ -29,14 +25,7 @@ import java.util.stream.Collectors;
 @Service
 public class AdditionalFilesPersistingService {
     private static final Logger log = LogManager.getLogger(AdditionalFilesPersistingService.class);
-
-    final Set<URI> relativeFilePathProperties;
-    final OntologyService ontologyService;
-
-    public AdditionalFilesPersistingService(WidocoPluginConfig config, OntologyService ontologyService) {
-        this.relativeFilePathProperties = config.getRelativeFilePathProperties();
-        this.ontologyService = ontologyService;
-    }
+    public static final Object FILE_PATHS_ADDITIONAL_PROPERTY = new Object();
 
     protected void copyFile(Path source, Path destinationDirectory) {
         log.trace("Moving additional file from {} to {}", source, destinationDirectory);
@@ -54,47 +43,16 @@ public class AdditionalFilesPersistingService {
         }
     }
 
+    @Transactional
     public void persistAdditionalFiles(ImportProcessContext context, Path filesDestination) {
-        final Path ontologyFile = context.getOntologyFilePath();
-        if (ontologyFile == null) {
-            log.debug("Skipping persisting additional files, no ontology file available");
-            return;
+        @SuppressWarnings("unchecked")
+        final List<Path> relativePaths = context.getAdditionalProperty(FILE_PATHS_ADDITIONAL_PROPERTY, List.class)
+                .orElseThrow();
+
+        for (Path relativeDestination : relativePaths) {
+            final Path safeSource = FileUtils.resolvePath(context.getTempFolder(), relativeDestination);
+            final Path absoluteDestination = filesDestination.resolve(relativeDestination);
+            copyFile(safeSource, absoluteDestination);
         }
-
-        final Path ontologyFileDir = ontologyFile.toFile().isFile()
-                ? Objects.requireNonNull(ontologyFile.getParent(), "Ontology file does not have a parent directory")
-                : ontologyFile;
-
-        for (URI property : relativeFilePathProperties) {
-            processProperty(context, property, ontologyFileDir, filesDestination);
-        }
-    }
-
-    protected void processProperty(
-            ImportProcessContext context, URI property, Path ontologyFileDir, Path filesDestination) {
-        final Set<Path> resolvedPaths = resolveProperty(context, property);
-        for (Path path : resolvedPaths) {
-            final Path safeSource = FileUtils.resolvePath(context.getTempFolder(), ontologyFileDir, path);
-            copyFile(safeSource, filesDestination.resolve(path));
-        }
-    }
-
-    protected Set<Path> resolveProperty(ImportProcessContext context, URI property) {
-        return ontologyService
-                .findValue(
-                        context.getTemporaryDatabaseContext(),
-                        context.getVersionSeries().getOntologyURI(),
-                        new ResourceURI(property))
-                .stream()
-                .map(str -> {
-                    try {
-                        return Path.of(str);
-                    } catch (Exception e) {
-                        log.debug("Skipping ontology property <{}>, invalid path: '{}'", property, str);
-                        return null;
-                    }
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
     }
 }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/AdditionalFilesPersistingService.java
@@ -1,0 +1,100 @@
+package cz.lukaskabc.ontology.ontopus.plugin.widoco.service;
+
+import cz.lukaskabc.ontology.ontopus.api.model.ImportProcessContext;
+import cz.lukaskabc.ontology.ontopus.api.util.FileUtils;
+import cz.lukaskabc.ontology.ontopus.core_model.exception.InternalException;
+import cz.lukaskabc.ontology.ontopus.core_model.exception.OntopusException;
+import cz.lukaskabc.ontology.ontopus.core_model.generated.Vocabulary;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.config.WidocoPluginConfig;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.service.OntologyService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Resolves {@link WidocoPluginConfig#relativeFilePathProperties} on the ontology and tries to match their values
+ * against local files, if a file is matched, it is moved to the destination directory.
+ */
+@Service
+public class AdditionalFilesPersistingService {
+    private static final Logger log = LogManager.getLogger(AdditionalFilesPersistingService.class);
+
+    final Set<URI> relativeFilePathProperties;
+    final OntologyService ontologyService;
+
+    public AdditionalFilesPersistingService(WidocoPluginConfig config, OntologyService ontologyService) {
+        this.relativeFilePathProperties = config.getRelativeFilePathProperties();
+        this.ontologyService = ontologyService;
+    }
+
+    protected void copyFile(Path source, Path destinationDirectory) {
+        log.trace("Moving additional file from {} to {}", source, destinationDirectory);
+        try {
+            Files.createDirectories(destinationDirectory);
+            Files.copy(source, destinationDirectory, StandardCopyOption.REPLACE_EXISTING, LinkOption.NOFOLLOW_LINKS);
+        } catch (IOException e) {
+            throw log.throwing(InternalException.builder()
+                    .errorType(Vocabulary.u_i_ontopus_problem_file_processing)
+                    .internalMessage("Failed to copy additional Widoco file")
+                    .detailMessageArguments(OntopusException.EMPTY_ARGUMENTS)
+                    .titleMessageCode("ontopus.plugin.widoco.error.copyAdditionalFile")
+                    .cause(e)
+                    .build());
+        }
+    }
+
+    public void persistAdditionalFiles(ImportProcessContext context, Path filesDestination) {
+        final Path ontologyFile = context.getOntologyFilePath();
+        if (ontologyFile == null) {
+            log.debug("Skipping persisting additional files, no ontology file available");
+            return;
+        }
+
+        final Path ontologyFileDir = ontologyFile.toFile().isFile()
+                ? Objects.requireNonNull(ontologyFile.getParent(), "Ontology file does not have a parent directory")
+                : ontologyFile;
+
+        for (URI property : relativeFilePathProperties) {
+            processProperty(context, property, ontologyFileDir, filesDestination);
+        }
+    }
+
+    protected void processProperty(
+            ImportProcessContext context, URI property, Path ontologyFileDir, Path filesDestination) {
+        final Set<Path> resolvedPaths = resolveProperty(context, property);
+        for (Path path : resolvedPaths) {
+            final Path safeSource = FileUtils.resolvePath(ontologyFileDir, path);
+            copyFile(safeSource, filesDestination.resolve(path));
+        }
+    }
+
+    protected Set<Path> resolveProperty(ImportProcessContext context, URI property) {
+        return ontologyService
+                .findValue(
+                        context.getTemporaryDatabaseContext(),
+                        context.getVersionSeries().getOntologyURI(),
+                        new ResourceURI(property))
+                .stream()
+                .map(str -> {
+                    try {
+                        return Path.of(str);
+                    } catch (Exception e) {
+                        log.debug("Skipping ontology property <{}>, invalid path: '{}'", property, str);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+}

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/WidocoService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/WidocoService.java
@@ -42,6 +42,7 @@ public class WidocoService {
     private final OntologyToFileSerializationService ontologyToFileSerializationService;
 
     private final WidocoProcessExecutionService exceptionService;
+    private final AdditionalFilesPersistingService additionalFilesPersistingService;
 
     private final WidocoPluginConfig config;
     private final URI systemUri;
@@ -49,10 +50,12 @@ public class WidocoService {
     public WidocoService(
             OntologyToFileSerializationService ontologyToFileSerializationService,
             WidocoProcessExecutionService exceptionService,
+            AdditionalFilesPersistingService additionalFilesPersistingService,
             WidocoPluginConfig widocoConfig,
             OntopusConfig ontopusConfig) {
         this.ontologyToFileSerializationService = ontologyToFileSerializationService;
         this.exceptionService = exceptionService;
+        this.additionalFilesPersistingService = additionalFilesPersistingService;
         this.config = widocoConfig;
         this.systemUri = ontopusConfig.getSystemUri();
     }
@@ -130,6 +133,7 @@ public class WidocoService {
         try {
             FileSystemUtils.deleteRecursively(filesDestination);
             FileSystemUtils.copyRecursively(widocoOutput, filesDestination);
+            additionalFilesPersistingService.persistAdditionalFiles(context, filesDestination);
         } catch (IOException e) {
             throw log.throwing(InternalException.builder()
                     .errorType(Vocabulary.u_i_ontopus_problem_file_processing)

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/WidocoService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/WidocoService.java
@@ -131,9 +131,9 @@ public class WidocoService {
                 context.getFinalDatabaseContext().toString());
         final Path filesDestination = FileUtils.resolvePath(config.getFilesDirectory(), Path.of(persistentContext));
         try {
+            additionalFilesPersistingService.persistAdditionalFiles(context, widocoOutput);
             FileSystemUtils.deleteRecursively(filesDestination);
             FileSystemUtils.copyRecursively(widocoOutput, filesDestination);
-            additionalFilesPersistingService.persistAdditionalFiles(context, filesDestination);
         } catch (IOException e) {
             throw log.throwing(InternalException.builder()
                     .errorType(Vocabulary.u_i_ontopus_problem_file_processing)

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/import_process/AdditionalFilesAnnotationInjectionService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/import_process/AdditionalFilesAnnotationInjectionService.java
@@ -1,0 +1,139 @@
+package cz.lukaskabc.ontology.ontopus.plugin.widoco.service.import_process;
+
+import cz.lukaskabc.ontology.ontopus.api.model.ImportProcessContext;
+import cz.lukaskabc.ontology.ontopus.api.model.JsonForm;
+import cz.lukaskabc.ontology.ontopus.api.model.ReadOnlyImportProcessContext;
+import cz.lukaskabc.ontology.ontopus.api.service.import_process.OntologyAnnotationInjectionService;
+import cz.lukaskabc.ontology.ontopus.api.util.FileUtils;
+import cz.lukaskabc.ontology.ontopus.core_model.exception.JsonFormSubmitException;
+import cz.lukaskabc.ontology.ontopus.core_model.model.id.ResourceURI;
+import cz.lukaskabc.ontology.ontopus.core_model.model.util.FormResult;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.config.WidocoPluginConfig;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.persistence.service.OntologyService;
+import cz.lukaskabc.ontology.ontopus.plugin.widoco.service.AdditionalFilesPersistingService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.rdf4j.model.Model;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.JsonNode;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Non-interactive service resolving common widoco properties with relative file paths and replacing them with paths
+ * relative to the widoco publication root.
+ *
+ * @see AdditionalFilesPersistingService
+ */
+@Service
+public class AdditionalFilesAnnotationInjectionService implements OntologyAnnotationInjectionService {
+    private static final Logger log = LogManager.getLogger(AdditionalFilesAnnotationInjectionService.class);
+    private final Set<URI> relativeFilePathProperties;
+    private final OntologyService ontologyService;
+
+    public AdditionalFilesAnnotationInjectionService(WidocoPluginConfig config, OntologyService ontologyService) {
+        this.relativeFilePathProperties = config.getRelativeFilePathProperties();
+        this.ontologyService = ontologyService;
+    }
+
+    @Override
+    public @Nullable JsonForm getJsonForm(ReadOnlyImportProcessContext context, @Nullable JsonNode previousFormData) {
+        return null;
+    }
+
+    @Override
+    public String getServiceName() {
+        return this.getClass().getName();
+    }
+
+    @Override
+    public Model handleSubmit(FormResult formResult, ImportProcessContext context) throws JsonFormSubmitException {
+        final Path ontologyFile = context.getOntologyFilePath();
+        if (ontologyFile == null) {
+            log.debug("Skipping persisting additional files, no ontology file available");
+            return EMPTY_MODEL;
+        }
+
+        final Path ontologyFileDir = ontologyFile.toFile().isFile()
+                ? Objects.requireNonNull(ontologyFile.getParent(), "Ontology file does not have a parent directory")
+                : ontologyFile;
+
+        context.setAdditionalProperty(
+                AdditionalFilesPersistingService.FILE_PATHS_ADDITIONAL_PROPERTY,
+                new ArrayList<Path>(relativeFilePathProperties.size()));
+
+        for (URI property : relativeFilePathProperties) {
+            processProperty(context, property, ontologyFileDir);
+        }
+
+        return EMPTY_MODEL;
+    }
+
+    protected void processProperty(ImportProcessContext context, URI property, Path ontologyFileDir) {
+        final Set<Path> resolvedPaths = resolveProperty(context, property);
+
+        @SuppressWarnings("unchecked")
+        final List<Path> relativePaths = context.getAdditionalProperty(
+                        AdditionalFilesPersistingService.FILE_PATHS_ADDITIONAL_PROPERTY, List.class)
+                .orElseThrow();
+
+        for (Path path : resolvedPaths) {
+            final Path safeSource = FileUtils.resolvePath(context.getTempFolder(), ontologyFileDir, path);
+            final Path relativeDestination = resolveDestinationRelativePath(context.getTempFolder(), safeSource);
+            log.debug(
+                    "Replacing relative file path in property <{}> from '{}' to '{}'",
+                    property,
+                    path,
+                    relativeDestination);
+
+            ontologyService.replaceObjectStringValue(
+                    context.getTemporaryDatabaseContext(),
+                    context.getVersionSeries().getOntologyURI(),
+                    new ResourceURI(property),
+                    path.toString(),
+                    relativeDestination.toString());
+            relativePaths.add(relativeDestination);
+        }
+    }
+
+    protected Path resolveDestinationRelativePath(Path absoluteRoot, Path source) {
+        String absoluteRootStr = absoluteRoot.toString();
+        String sourceStr = source.toString();
+        int commonPrefix = 0;
+        for (int i = 0; i < Math.min(absoluteRootStr.length(), sourceStr.length()); i++) {
+            if (absoluteRootStr.charAt(i) == sourceStr.charAt(i)) {
+                commonPrefix++;
+            } else {
+                break;
+            }
+        }
+        return FileUtils.forceRelativePath(sourceStr.substring(commonPrefix));
+    }
+
+    protected Set<Path> resolveProperty(ImportProcessContext context, URI property) {
+        return ontologyService
+                .findValue(
+                        context.getTemporaryDatabaseContext(),
+                        context.getVersionSeries().getOntologyURI(),
+                        new ResourceURI(property))
+                .stream()
+                .map(str -> {
+                    try {
+
+                        return Path.of(str);
+                    } catch (Exception e) {
+                        log.debug("Skipping ontology property <{}>, invalid path: '{}'", property, str);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+}

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/import_process/WidocoSerializationAnnotationsInjectionService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/import_process/WidocoSerializationAnnotationsInjectionService.java
@@ -28,8 +28,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+/**
+ * Adds {@code https://w3id.org/widoco/vocab#XXXXSerialization} properties to the ontology in order to document them
+ * using Widoco.
+ */
 @Service
-public class WidocoAnnotationsInjectionService implements OntologyAnnotationInjectionService {
+public class WidocoSerializationAnnotationsInjectionService implements OntologyAnnotationInjectionService {
     private static final Map<String, @Nullable String> WIDOCO_SERIALIZATION_TO_FILE_EXTENSION_MAP =
             Map.<String, @Nullable String>of(
                     Vocabulary.s_p_widoco_ntSerialization,
@@ -44,7 +48,8 @@ public class WidocoAnnotationsInjectionService implements OntologyAnnotationInje
     private final OntopusConfig ontopusConfig;
     private final WidocoPluginConfig widocoPluginConfig;
 
-    public WidocoAnnotationsInjectionService(OntopusConfig ontopusConfig, WidocoPluginConfig widocoPluginConfig) {
+    public WidocoSerializationAnnotationsInjectionService(
+            OntopusConfig ontopusConfig, WidocoPluginConfig widocoPluginConfig) {
         this.ontopusConfig = ontopusConfig;
         this.widocoPluginConfig = widocoPluginConfig;
     }

--- a/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/init/FilesDirectoryInitializationService.java
+++ b/plugins/widoco/src/main/java/cz/lukaskabc/ontology/ontopus/plugin/widoco/service/init/FilesDirectoryInitializationService.java
@@ -1,43 +1,15 @@
 package cz.lukaskabc.ontology.ontopus.plugin.widoco.service.init;
 
-import cz.lukaskabc.ontology.ontopus.api.service.core.InitializationService;
-import cz.lukaskabc.ontology.ontopus.core_model.exception.InitializationException;
+import cz.lukaskabc.ontology.ontopus.api.service.init.DirectoryInitializationService;
 import cz.lukaskabc.ontology.ontopus.plugin.widoco.config.WidocoPluginConfig;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import java.io.File;
-import java.nio.file.Files;
-
 /** Ensures that {@link WidocoPluginConfig#filesDirectory} exists and is writable and readable directory */
-@Order(500)
+@Order(DirectoryInitializationService.ORDER)
 @Component
-public class FilesDirectoryInitializationService implements InitializationService {
-    private final WidocoPluginConfig config;
-
+public class FilesDirectoryInitializationService extends DirectoryInitializationService {
     public FilesDirectoryInitializationService(WidocoPluginConfig config) {
-        this.config = config;
-    }
-
-    @Override
-    public void initialize() {
-        final File filesDirectory = config.getFilesDirectory().toFile();
-        if (!filesDirectory.exists()) {
-            final boolean success = filesDirectory.mkdirs();
-            if (!success) {
-                throw new InitializationException(
-                        "Failed to create files directory at " + filesDirectory.getAbsolutePath());
-            }
-        }
-        if (!filesDirectory.isDirectory()) {
-            throw new InitializationException(
-                    "Files directory is missing or not a directory: " + filesDirectory.getAbsolutePath());
-        }
-        if (!Files.isWritable(filesDirectory.toPath())) {
-            throw new InitializationException("Files directory is not writable: " + filesDirectory.getAbsolutePath());
-        }
-        if (!Files.isReadable(filesDirectory.toPath())) {
-            throw new InitializationException("Files directory is not readable: " + filesDirectory.getAbsolutePath());
-        }
+        super(config.getFilesDirectory());
     }
 }

--- a/plugins/widoco/src/main/resources/language/en.json
+++ b/plugins/widoco/src/main/resources/language/en.json
@@ -8,6 +8,7 @@
         "detailLog": "An error occurred during Widoco execution: {0}, the full log is accessible at {1}"
       },
       "persistOutput": "Failed to persist Widoco output",
+      "copyAdditionalFile": "Failed to copy additional Widoco file",
       "noWidocoOutputFolder": "Failed to resolve Widoco root output folder"
     },
     "service": {

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <jackson.annotations.version>2.22</jackson.annotations.version>
         <jackson.version>3.2.1</jackson.version>
         <java.version>25</java.version>
-        <jopa.version>2.11.1</jopa.version>
+        <jopa.version>2.11.2</jopa.version>
         <nullaway.version>0.13.8</nullaway.version>
         <org.immutables.version>2.12.2</org.immutables.version>
         <rdf4j.version>5.3.2</rdf4j.version> <!-- TODO: update to 6.0.0 -->


### PR DESCRIPTION
Resolves #26 

# Added
- Support for including logo and diagram in Widoco documentation (#26)  
When the ontology references a file using a relative path in a supported property, the file will be included in the published files served by OntoPuS

Supported properties:
- Diagram (https://dgarijo.github.io/Widoco/doc/bestPractices/index-en.html#diagram)  
`http://schema.org/image`, `http://xmlns.com/foaf/0.1/depiction`

- Logo (https://dgarijo.github.io/Widoco/doc/bestPractices/index-en.html#logo)  
`http://schema.org/logo`, `http://xmlns.com/foaf/0.1/logo`